### PR TITLE
updated domain from alpha.irccloud.com to www.irccloud.com

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -1,4 +1,3 @@
-
 #import "AppDelegate.h"
 
 @interface AppDelegate (PrivateMethods)
@@ -35,7 +34,7 @@
   [[NSURLCache sharedURLCache] removeAllCachedResponses];
 
   NSString *url = [[NSUserDefaults standardUserDefaults] valueForKey:@"url"];
-  if (!url) url = @"https://alpha.irccloud.com/";
+  if (!url) url = @"https://www.irccloud.com/";
 
   NSLog(@"Connecting to %@", url);
 


### PR DESCRIPTION
Since irccloud did the server upgrade, alpha no longer does a redirect to www, so I changed the domain back to www.
