### PR TITLE
Fix #15: don’t crash on title change to empty string

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -69,6 +69,10 @@
 - (void)titleDidChange:(NSString *)title {
   NSUInteger unread = 0;
 
+  if ([title length] == 0) {
+    NSLog(@"WARNING: title changed to an empty string.");
+    return;
+  }
   if ([[title substringToIndex:1] isEqualToString:@"*"]) {
     title = [title substringFromIndex:2];
   } else if ([[title substringToIndex:1] isEqualToString:@"("]) {


### PR DESCRIPTION
Sometimes, on 10.9, WebKit sends an event indicating that the document title has changed to @"", which would cause substring operations in the window title generation method to crash the app. This guards against the empty string.
